### PR TITLE
Navigation changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production webpack --progress --config webpack/webpack.config.js",
+    "build-watch": "NODE_ENV=production webpack --progress --config webpack/webpack.config.js --watch",
     "dev": "NODE_ENV=development webpack-dev-server --config webpack/webpack.config.js --hot --inline --content-base example/",
     "lint": "eslint --color --ext .js src example",
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://bitbucket.org/lemontech/ux"
   },
   "scripts": {
-    "build": "NODE_ENV=production webpack --progress -p --config webpack/webpack.config.js",
+    "build": "NODE_ENV=production webpack --progress --config webpack/webpack.config.js",
     "dev": "NODE_ENV=development webpack-dev-server --config webpack/webpack.config.js --hot --inline --content-base example/",
     "lint": "eslint --color --ext .js src example",
     "prepublish": "npm run build",

--- a/src/main/Navigation/Navigation.js
+++ b/src/main/Navigation/Navigation.js
@@ -3,7 +3,11 @@ import childrenPropType from 'propTypes/children'
 import classNames from 'classnames'
 
 const Navigation = props =>
-  <div className={`navbar navbar-fixed-top navbar-${props.theme}`}>
+  <div
+    className={classNames('navbar', 'navbar-fixed-top',
+      `navbar-${props.theme}`, props.className,
+    )}
+    >
     <div className="container-max">
       <div className="navbar-header">
         <button type="button" className="navbar-toggle collapsed pull-left" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
@@ -38,6 +42,7 @@ Navigation.propTypes = {
   align: PropTypes.oneOf(['left', 'center']).isRequired,
   brand: PropTypes.node,
   children: childrenPropType,
+  className: PropTypes.string,
   navigationOptions: childrenPropType,
   theme: PropTypes.oneOf(['default', 'inverse']).isRequired,
 }

--- a/src/main/Navigation/Navigation.js
+++ b/src/main/Navigation/Navigation.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import childrenPropType from 'propTypes/children'
+import classNames from 'classnames'
 
 const Navigation = props =>
   <div className={`navbar navbar-fixed-top navbar-${props.theme}`}>
@@ -21,7 +22,11 @@ const Navigation = props =>
       </div>
 
       <div className="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-        <ul className="nav navbar-nav">
+        <ul
+          className={classNames('nav navbar-nav', {
+            'navbar-nav--align-left': props.align === 'left',
+          })}
+          >
           {props.children}
         </ul>
         {props.navigationOptions}
@@ -30,6 +35,7 @@ const Navigation = props =>
   </div>
 
 Navigation.propTypes = {
+  align: PropTypes.oneOf(['left', 'center']).isRequired,
   brand: PropTypes.node,
   children: childrenPropType,
   navigationOptions: childrenPropType,
@@ -37,6 +43,7 @@ Navigation.propTypes = {
 }
 
 Navigation.defaultProps = {
+  align: 'center',
   theme: 'default',
 }
 

--- a/src/main/Navigation/Navigation.js
+++ b/src/main/Navigation/Navigation.js
@@ -13,7 +13,11 @@ const Navigation = props =>
           <span className="sr-only">Toggle navigation</span>
           <i className="fa fa-search" />
         </button>
-        <a className="navbar-brand" href="#">{props.brand}</a>
+        {props.brand &&
+          <div className="navbar-brand">
+            {props.brand}
+          </div>
+        }
       </div>
 
       <div className="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -26,7 +30,7 @@ const Navigation = props =>
   </div>
 
 Navigation.propTypes = {
-  brand: PropTypes.string,
+  brand: PropTypes.node,
   children: childrenPropType,
   navigationOptions: childrenPropType,
   theme: PropTypes.oneOf(['default', 'inverse']).isRequired,

--- a/src/main/NavigationItem/NavigationItem.js
+++ b/src/main/NavigationItem/NavigationItem.js
@@ -7,7 +7,8 @@ const NavigationItem = props => {
   return (
     <li className={classNames({ active: isActive })}>
       <Component {...other}>
-        <i className={`fa mr-xs ${icon}`} />
+        {icon}
+        {' '}
         <span className="hidden-sm">{label}</span>
       </Component>
     </li>
@@ -17,7 +18,7 @@ const NavigationItem = props => {
 NavigationItem.propTypes = {
   component: PropTypes.node,
   isActive: PropTypes.bool,
-  icon: PropTypes.string,
+  icon: PropTypes.node,
   label: PropTypes.string,
 }
 

--- a/src/main/NavigationItem/NavigationItem.js
+++ b/src/main/NavigationItem/NavigationItem.js
@@ -2,25 +2,46 @@ import React, { PropTypes } from 'react'
 import classNames from 'classnames'
 
 const NavigationItem = props => {
-  const { component: Component, isActive, icon, label, ...other } = props
+  const { component: Component, isActive, icon, label, children, ...other } = props
+  const isDropdown = children != null
 
   return (
-    <li className={classNames({ active: isActive })}>
-      <Component {...other}>
+    <li
+      className={classNames({
+        active: isActive,
+        dropdown: isDropdown,
+      })}
+      >
+      <Component
+        {...other}
+        data-toggle={isDropdown ? 'dropdown' : undefined}
+        >
         {icon &&
           <span className="mr-xs navigation-item__icon">
             {icon}
           </span>
         }
+
         <span className="hidden-sm">
           {label}
         </span>
+
+        {isDropdown &&
+          <span className="caret navigation-item__caret" />
+        }
       </Component>
+
+      {isDropdown &&
+        <ul className="dropdown-menu">
+          {children}
+        </ul>
+      }
     </li>
   )
 }
 
 NavigationItem.propTypes = {
+  children: PropTypes.node,
   component: PropTypes.node,
   isActive: PropTypes.bool,
   icon: PropTypes.node,

--- a/src/main/NavigationItem/NavigationItem.js
+++ b/src/main/NavigationItem/NavigationItem.js
@@ -56,6 +56,7 @@ NavigationItem.propTypes = {
 
 NavigationItem.defaultProps = {
   component: 'a',
+  containerProps: {},
 }
 
 export default NavigationItem

--- a/src/main/NavigationItem/NavigationItem.js
+++ b/src/main/NavigationItem/NavigationItem.js
@@ -7,9 +7,14 @@ const NavigationItem = props => {
   return (
     <li className={classNames({ active: isActive })}>
       <Component {...other}>
-        {icon}
-        {' '}
-        <span className="hidden-sm">{label}</span>
+        {icon &&
+          <span className="mr-xs navigation-item__icon">
+            {icon}
+          </span>
+        }
+        <span className="hidden-sm">
+          {label}
+        </span>
       </Component>
     </li>
   )

--- a/src/main/NavigationItem/NavigationItem.js
+++ b/src/main/NavigationItem/NavigationItem.js
@@ -1,64 +1,80 @@
 import React, { PropTypes } from 'react'
 import classNames from 'classnames'
 
-const NavigationItem = props => {
-  const {
-    component: Component, isActive, icon, label, children, containerProps,
-    ...other
-  } = props
+export default class NavigationItem extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    containerProps: PropTypes.object,
+    component: PropTypes.oneOfType([
+      PropTypes.string, PropTypes.func,
+    ]),
+    isActive: PropTypes.bool,
+    icon: PropTypes.node,
+    label: PropTypes.node,
+  }
 
-  const isDropdown = children != null
+  static defaultProps = {
+    component: 'a',
+    containerProps: {},
+  }
 
-  return (
-    <li
-      {...containerProps}
-      className={classNames(containerProps.className, {
-        active: isActive,
-        dropdown: isDropdown,
-      })}
-      >
-      <Component
-        {...other}
-        data-toggle={isDropdown ? 'dropdown' : undefined}
+  static contextTypes = {
+    isNestedNavigationItem: PropTypes.bool,
+  }
+
+  static childContextTypes = {
+    isNestedNavigationItem: PropTypes.bool,
+  }
+
+  getChildContext() {
+    return {
+      isNestedNavigationItem: true,
+    }
+  }
+
+  render() {
+    const {
+      component: Component, isActive, icon, label, children, containerProps,
+      ...other
+    } = this.props
+
+    const isNested = this.context.isNestedNavigationItem || false
+    const isDropdown = children != null
+
+    return (
+      <li
+        {...containerProps}
+        className={classNames(containerProps.className, {
+          active: isActive,
+          dropdown: isDropdown,
+          'navigation-item--top-level': !isNested,
+        })}
         >
-        {icon &&
-          <span className="mr-xs navigation-item__icon">
-            {icon}
-          </span>
-        }
+        <Component
+          {...other}
+          data-toggle={isDropdown ? 'dropdown' : undefined}
+          >
+          {icon &&
+            <span className="mr-xs navigation-item__icon">
+              {icon}
+            </span>
+          }
 
-        <span className="hidden-sm">
-          {label}
-        </span>
+          <span className={classNames({ 'hidden-sm': !isNested })}>
+            {label}
+          </span>
+
+          {isDropdown &&
+            <span className="caret navigation-item__caret" />
+          }
+        </Component>
 
         {isDropdown &&
-          <span className="caret navigation-item__caret" />
+          <ul className="dropdown-menu">
+            {children}
+          </ul>
         }
-      </Component>
-
-      {isDropdown &&
-        <ul className="dropdown-menu">
-          {children}
-        </ul>
-      }
-    </li>
-  )
+      </li>
+    )
+  }
 }
-
-NavigationItem.propTypes = {
-  children: PropTypes.node,
-  containerProps: PropTypes.object,
-  component: PropTypes.oneOfType([
-    PropTypes.string, PropTypes.func,
-  ]),
-  isActive: PropTypes.bool,
-  icon: PropTypes.node,
-  label: PropTypes.node,
-}
-
-NavigationItem.defaultProps = {
-  component: 'a',
-  containerProps: {},
-}
-
-export default NavigationItem

--- a/src/main/NavigationItem/NavigationItem.js
+++ b/src/main/NavigationItem/NavigationItem.js
@@ -48,7 +48,9 @@ const NavigationItem = props => {
 NavigationItem.propTypes = {
   children: PropTypes.node,
   containerProps: PropTypes.object,
-  component: PropTypes.func,
+  component: PropTypes.oneOfType([
+    PropTypes.string, PropTypes.func,
+  ]),
   isActive: PropTypes.bool,
   icon: PropTypes.node,
   label: PropTypes.node,

--- a/src/main/NavigationItem/NavigationItem.js
+++ b/src/main/NavigationItem/NavigationItem.js
@@ -2,12 +2,17 @@ import React, { PropTypes } from 'react'
 import classNames from 'classnames'
 
 const NavigationItem = props => {
-  const { component: Component, isActive, icon, label, children, ...other } = props
+  const {
+    component: Component, isActive, icon, label, children, containerProps,
+    ...other
+  } = props
+
   const isDropdown = children != null
 
   return (
     <li
-      className={classNames({
+      {...containerProps}
+      className={classNames(containerProps.className, {
         active: isActive,
         dropdown: isDropdown,
       })}
@@ -42,6 +47,7 @@ const NavigationItem = props => {
 
 NavigationItem.propTypes = {
   children: PropTypes.node,
+  containerProps: PropTypes.object,
   component: PropTypes.node,
   isActive: PropTypes.bool,
   icon: PropTypes.node,

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -4,3 +4,4 @@
 @import "components/block";
 @import "components/links";
 @import "components/typeset";
+@import "components/navigation-item";

--- a/src/styles/bootstrap/_navbar.scss
+++ b/src/styles/bootstrap/_navbar.scss
@@ -163,8 +163,9 @@
 
 .navbar-brand {
   //float: left;
-  display: inline-block;
-  padding: $navbar-padding-vertical $navbar-padding-horizontal;
+  display: flex;
+  align-items: center;
+  padding: 0 $navbar-padding-horizontal;
   font-size: $font-size-large;
   line-height: $line-height-computed;
   height: $navbar-height;

--- a/src/styles/bootstrap/_navbar.scss
+++ b/src/styles/bootstrap/_navbar.scss
@@ -494,10 +494,19 @@
       .open .dropdown-menu {
         > li > a {
           color: $navbar-default-link-color;
+
+          path[fill] {
+            fill: $navbar-default-link-color;
+          }
+
           &:hover,
           &:focus {
             color: $navbar-default-link-hover-color;
             background-color: $navbar-default-link-hover-bg;
+
+            path[fill] {
+              fill: $navbar-default-link-hover-color;
+            }
           }
         }
         > .active > a {
@@ -506,6 +515,10 @@
           &:focus {
             color: $navbar-default-link-active-color;
             background-color: $navbar-default-link-active-bg;
+
+            path[fill] {
+              fill: $navbar-default-link-active-color;
+            }
           }
         }
         > .disabled > a {
@@ -514,6 +527,10 @@
           &:focus {
             color: $navbar-default-link-disabled-color;
             background-color: $navbar-default-link-disabled-bg;
+
+            path[fill] {
+              fill: $navbar-default-link-disabled-color;
+            }
           }
         }
       }
@@ -654,10 +671,19 @@
         }
         > li > a {
           color: $navbar-inverse-link-color;
+
+          path[fill] {
+            fill: $navbar-inverse-link-color;
+          }
+
           &:hover,
           &:focus {
             color: $navbar-inverse-link-hover-color;
             background-color: $navbar-inverse-link-hover-bg;
+
+            path[fill] {
+              fill: $navbar-inverse-link-hover-color;
+            }
           }
         }
         > .active > a {
@@ -666,6 +692,10 @@
           &:focus {
             color: $navbar-inverse-link-active-color;
             background-color: $navbar-inverse-link-active-bg;
+
+            path[fill] {
+              fill: $navbar-inverse-link-active-color;
+            }
           }
         }
         > .disabled > a {
@@ -674,6 +704,10 @@
           &:focus {
             color: $navbar-inverse-link-disabled-color;
             background-color: $navbar-inverse-link-disabled-bg;
+
+            path[fill] {
+              fill: $navbar-inverse-link-disabled-color;
+            }
           }
         }
       }

--- a/src/styles/bootstrap/_navbar.scss
+++ b/src/styles/bootstrap/_navbar.scss
@@ -235,6 +235,8 @@
     padding-top:    10px;
     padding-bottom: 10px;
     line-height: $line-height-computed;
+    display: flex;
+    align-items: center;
   }
 
   @media (max-width: $grid-float-breakpoint-max) {
@@ -269,8 +271,9 @@
     > li {
       float: left;
       > a {
-        padding-top:    $navbar-padding-vertical;
-        padding-bottom: $navbar-padding-vertical;
+        padding-top:    0;
+        padding-bottom: 0;
+        height: $navbar-height;
       }
     }
   }

--- a/src/styles/bootstrap/_navbar.scss
+++ b/src/styles/bootstrap/_navbar.scss
@@ -482,6 +482,10 @@
       &:focus {
         background-color: $navbar-default-link-active-bg;
         color: $navbar-default-link-active-color;
+
+        path[fill] {
+          fill: $navbar-default-link-active-color;
+        }
       }
     }
 
@@ -587,6 +591,10 @@
       &:focus {
         color: $navbar-inverse-link-active-color;
         background-color: $navbar-inverse-link-active-bg;
+
+        path[fill] {
+          fill: $navbar-inverse-link-active-color;
+        }
       }
     }
     > .disabled > a {
@@ -595,6 +603,10 @@
       &:focus {
         color: $navbar-inverse-link-disabled-color;
         background-color: $navbar-inverse-link-disabled-bg;
+
+        path[fill] {
+          fill: $navbar-inverse-link-disabled-color;
+        }
       }
     }
   }
@@ -624,6 +636,10 @@
       &:focus {
         background-color: $navbar-inverse-link-active-bg;
         color: $navbar-inverse-link-active-color;
+
+        path[fill] {
+          fill: $navbar-inverse-link-active-color;
+        }
       }
     }
 

--- a/src/styles/bootstrap/_navbar.scss
+++ b/src/styles/bootstrap/_navbar.scss
@@ -417,10 +417,18 @@
     > li > a {
       color: $navbar-default-link-color;
 
+      path[fill] {
+        fill: $navbar-default-link-color;
+      }
+
       &:hover,
       &:focus {
         color: $navbar-default-link-hover-color;
         background-color: $navbar-default-link-hover-bg;
+
+        path[fill] {
+          fill: $navbar-default-link-hover-color;
+        }
       }
     }
     > .active > a {
@@ -429,6 +437,10 @@
       &:focus {
         color: $navbar-default-link-active-color;
         background-color: $navbar-default-link-active-bg;
+
+        path[fill] {
+          fill: $navbar-default-link-active-color;
+        }
       }
     }
     > .disabled > a {
@@ -437,6 +449,10 @@
       &:focus {
         color: $navbar-default-link-disabled-color;
         background-color: $navbar-default-link-disabled-bg;
+
+        path[fill] {
+          fill: $navbar-default-link-disabled-color;
+        }
       }
     }
   }
@@ -551,10 +567,18 @@
     > li > a {
       color: $navbar-inverse-link-color;
 
+      path[fill] {
+        fill: $navbar-inverse-link-color;
+      }
+
       &:hover,
       &:focus {
         color: $navbar-inverse-link-hover-color;
         background-color: $navbar-inverse-link-hover-bg;
+
+        path[fill] {
+          fill: $navbar-inverse-link-hover-color;
+        }
       }
     }
     > .active > a {

--- a/src/styles/bootstrap/_navbar.scss
+++ b/src/styles/bootstrap/_navbar.scss
@@ -702,3 +702,8 @@
     }
   }
 }
+
+.navbar-nav .dropdown-menu > li > a {
+  display: flex;
+  align-items: center;
+}

--- a/src/styles/components/_navbar.scss
+++ b/src/styles/components/_navbar.scss
@@ -3,6 +3,10 @@
     display: inline-block;
     float: none;
     vertical-align: top;
+
+    &.navbar-nav--align-left {
+      float: left;
+    }
   }
 
   .navbar .navbar-collapse {

--- a/src/styles/components/_navigation-item.scss
+++ b/src/styles/components/_navigation-item.scss
@@ -1,0 +1,9 @@
+.navigation-item__icon {
+  display: flex;
+}
+
+@media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+  .navigation-item__icon {
+    margin-right: 0 !important;
+  }
+}

--- a/src/styles/components/_navigation-item.scss
+++ b/src/styles/components/_navigation-item.scss
@@ -2,7 +2,7 @@
   display: flex;
 }
 
-.navigation-item__caret {
+.navigation-item__caret.caret {
   margin-top: 4px;
 }
 

--- a/src/styles/components/_navigation-item.scss
+++ b/src/styles/components/_navigation-item.scss
@@ -2,6 +2,10 @@
   display: flex;
 }
 
+.navigation-item__caret {
+  margin-top: 4px;
+}
+
 @media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
   .navigation-item__icon {
     margin-right: 0 !important;

--- a/src/styles/components/_navigation-item.scss
+++ b/src/styles/components/_navigation-item.scss
@@ -7,7 +7,7 @@
 }
 
 @media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
-  .navigation-item__icon {
+  .navigation-item--top-level > a > .navigation-item__icon {
     margin-right: 0 !important;
   }
 }

--- a/webpack/config/production.config.js
+++ b/webpack/config/production.config.js
@@ -22,12 +22,6 @@ module.exports = new Config().extend('webpack/config/base.config.js').merge({
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    new webpack.optimize.UglifyJsPlugin({
-      minimize: true,
-      compress: {
-        warnings: false,
-      },
-    }),
     new CleanWebpackPlugin(['lib'], {
       root: path.resolve('.'),
       verbose: false,


### PR DESCRIPTION
## Improvements
- `Navigation.propTypes.brand` now is a node instead of a string.
- The navbar links and brand are now aligned using flexbox instead of hardcoded padding. This allows the use of arbitrary heights to, for example, use a full sized logo as the brand.
- Adds support for SVG icons on the navbar links.
- `NavigationItem` now supports nested links (only one level deep). Example:

```jsx
<Navigation>
  <NavigationItem label="Menu 1" />
  <NavigationItem label="Menu 2">
    <NavigationItem label="Menu 2.1" />
    <NavigationItem label="Menu 2.2" />
  </NavigationItem>
</Navigation>
```

- `NavigationItem.propTypes.component` now accepts native html elements and components.
- Adds `NavigationItem.propTypes.containerProps` to pass props to the link wrapper (the `li` node).
- Adds `Navigation.propTypes.align` to change the main links alignment. You can choose between `left` and `center` (default).
- Adds `Navigation.propTypes.className` to add a class to the top level wrapper of the navigation.

## Breaking changes
- `NavigationItem.propTypes.icon` now is a node. Previously this prop was a string representing the name of a Font Awesome icon, but it should be agnostic to the app icons library. Migration:

```diff
-<NavigationItem icon="fa-calendar" />
+<NavigationItem icon={<i className="fa fa-calendar" />} />
```

## Other changes
- Assets are no longer minified during the build process. The host application should be responsible for minifying -or not- its assets. This makes debugging a lot easier.
- Adds `build-watch` script to continuously build for production. This helps testing changes on Portrait while integrating on other projects.