### PR TITLE
Crear callback para click en agregar nueva opción

### DIFF
--- a/src/components/controls/Select/Select.js
+++ b/src/components/controls/Select/Select.js
@@ -162,6 +162,11 @@ export default class Select extends PureComponent {
     onFocus: PropTypes.func,
 
     /**
+     * Function that returns input value
+     */
+    onNewOption: PropTypes.func,
+
+    /**
      * Function that returns the view to display an option in the list.
      */
     optionRenderer: PropTypes.func.isRequired,
@@ -220,6 +225,7 @@ export default class Select extends PureComponent {
     inputRenderer: defaultInputRenderer,
     menuRenderer: defaultMenuRenderer,
     newOptionBuilder: defaultNewOptionBuilder,
+    onNewOption: defaultOnNewOption,
     optionsFilter: defaultOptionsFilter,
     optionSearchTerms: defaultOptionSearchTerms,
     optionRenderer: defaultOptionRenderer,
@@ -672,6 +678,10 @@ export default class Select extends PureComponent {
   }
 
   handleCreateOptionClick = () => {
+    if (this.props.onNewOption) {
+      return this.props.onNewOption(this.state.input)
+    }
+
     const newOption = this.props.newOptionBuilder({
       label: this.state.input,
       value: NEW_VALUE,


### PR DESCRIPTION
# Requerimiento

Para el selector de proyectos de TBX es necesario llamar un metodo de backbone al hacer intentar agregar una nueva opción 

# Solución

Se agrega una prop que se ejecuta antes que el proceso por defecto para la creación de una prop nueva.

# Como probar

En un el penultimo ejemplo de [portrait](http://localhost:8080/components/Select) agregue esta prop `onNewOption={() => console.log('test')}` al componente Select, al hacer click en el +, en el footer o presionar enter al no encontrar una opcion, debe ejecutar solo el console log y no hacer nada mas.

