### PR TITLE
v0.6.2

### DIFF
--- a/src/components/controls/Select/Option.js
+++ b/src/components/controls/Select/Option.js
@@ -48,7 +48,7 @@ export default class Option extends PureComponent {
       style.backgroundColor = color
     }
     else if (focused && color) {
-      style.backgroundColor = tinycolor(color).lighten(35).toHexString()
+      style.backgroundColor = tinycolor.mix(color, '#FFF', 90).toHexString()
     }
 
     if (style.backgroundColor) {

--- a/src/components/controls/Select/Option.js
+++ b/src/components/controls/Select/Option.js
@@ -52,7 +52,7 @@ export default class Option extends PureComponent {
     }
 
     if (style.backgroundColor) {
-      style.color = tinycolor.mostReadable(style.backgroundColor, ['#697D91', '#FFF'])
+      style.color = tinycolor.mostReadable(style.backgroundColor, ['#333', '#FFF'])
     }
 
     return (

--- a/src/components/controls/Select/Select-test.js
+++ b/src/components/controls/Select/Select-test.js
@@ -1385,7 +1385,7 @@ describe('Select', () => {
       component.setState({ focusedElement: 0 })
 
       expect(component.find(Option).getDOMNode().style['background-color']).toBe(
-        tinycolor('rgb(255, 0, 0)').lighten(35).toRgbString(),
+        tinycolor.mix('rgb(255, 0, 0)', '#FFF', 90).toRgbString(),
       )
     })
   })


### PR DESCRIPTION
## Changes
- Uses a more visually friendly color transformation to highlight the focused option in the `Select` component.

## QA
- Go to http://localhost:8080/components/Select
- Add `color={rgb(0, 140, 153)}` to any example.

It should display like this:

<img width="252" alt="captura de pantalla 2017-09-14 a la s 16 08 30" src="https://user-images.githubusercontent.com/1670771/30450890-8f65c258-9968-11e7-8dd0-24640c7921e7.png">

Instead of this:

<img width="250" alt="captura de pantalla 2017-09-14 a la s 16 07 44" src="https://user-images.githubusercontent.com/1670771/30450900-972c95f2-9968-11e7-919b-d92a9e782169.png">

