### PR TITLE
TF-2406 Escapar caracteres especiales en búsqueda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 cache: yarn
 node_js:
-  - "6"
-  - "node"
+  - "lts/*"
 notifications:
   email: false
 install:

--- a/src/components/controls/Select/Select-test.js
+++ b/src/components/controls/Select/Select-test.js
@@ -1906,6 +1906,35 @@ describe('Select', () => {
         },
       ])
     })
+
+    it('highlights special characters', () => {
+      const terms = defaultOptionSearchTerms({
+        cleanDiacritics: deburr,
+        option: { label: 'hello (world)' },
+        search: '(wor',
+      })
+
+      expect(terms).toEqual([
+        {
+          text: 'hello ',
+          matches: false,
+          fromIndex: 0,
+          toIndex: 6,
+        },
+        {
+          text: '(wor',
+          matches: true,
+          fromIndex: 6,
+          toIndex: 10,
+        },
+        {
+          text: 'ld)',
+          matches: false,
+          fromIndex: 10,
+          toIndex: 13,
+        },
+      ])
+    })
   })
 
   describe('defaultOptionsFilter', () => {

--- a/src/components/controls/Select/Select-test.js
+++ b/src/components/controls/Select/Select-test.js
@@ -1940,6 +1940,23 @@ describe('Select', () => {
         expect(filtered).toBe(options)
       })
     })
+
+    it('allows to search special characters', () => {
+      const filtered = defaultOptionsFilter({
+        cleanDiacritics: deburr,
+        search: '( * /',
+        options: [
+          { label: '(test*/option)' },
+          { label: 'óption 27' },
+          { label: 'Ôption 10' },
+          { label: 'Option 23' },
+        ],
+      })
+
+      expect(filtered).toEqual([
+        { label: '(test*/option)' },
+      ])
+    })
   })
 
   describe('defaultPlaceholder', () => {

--- a/src/components/controls/Select/defaults/optionSearchTerms.js
+++ b/src/components/controls/Select/defaults/optionSearchTerms.js
@@ -1,5 +1,10 @@
+import escapeRegExp from 'lodash/escapeRegExp'
+
 export default ({ cleanDiacritics, option, search }) => {
-  const pattern = `(${cleanDiacritics(search.trim()).split(/\s+/).join('|')})`
+  const pattern = `(${cleanDiacritics(search.trim())
+    .split(/\s+/)
+    .map(escapeRegExp)
+    .join('|')})`
   const regexp = new RegExp(pattern, 'ig')
   const terms = []
   let currentIndex = 0

--- a/src/components/controls/Select/defaults/optionsFilter.js
+++ b/src/components/controls/Select/defaults/optionsFilter.js
@@ -1,10 +1,12 @@
+import escapeRegExp from 'lodash/escapeRegExp'
+
 export default ({ cleanDiacritics, options, search }) => {
   if (!search.trim()) {
     return options
   }
 
   const words = cleanDiacritics(search.trim()).split(/\s+/)
-  const pattern = words.map(word => `(?=.*${word})`).join('')
+  const pattern = words.map(word => `(?=.*${escapeRegExp(word)})`).join('')
   const regexp = new RegExp(pattern, 'ig')
 
   return options.filter(option => regexp.test(cleanDiacritics(option.label)))


### PR DESCRIPTION
Ver https://github.com/LemontechSA/timebillingx-desktop/pull/38

En desktop no se está usando `portrait` porque no soporta [tree shaking](https://webpack.js.org/guides/tree-shaking/) y no vale la pena agregar el peso de todos los componentes cuando solo necesito `Select`.

# QA
- Ejecute `yarn dev`.
- Vaya al componente `Select`.
- Modifique cualquier ejemplo y agregue una opción que tenga caracteres especiales en su label. Por ej, `(holi)`.
- Busque esa opción en el selector.